### PR TITLE
fix offset between multiple ifd regions

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -532,7 +532,7 @@ export const dictToBytes = (
     entriesLength = 2 + tagCount * 12;
   }
   let entries = '';
-  let values = '';
+  let values = '\x00\x00\x00\x00';
   let key;
 
   for (key in ifdObj) {


### PR DESCRIPTION
When the exif data in image contains GPS Location parameters, the offset between IFD regions is not set correctly according to the TIFF specification. This fix corrects this issue. 
See: https://github.com/hMatoba/piexifjs/issues/70